### PR TITLE
Accept an element when bootstrapping Dorsal

### DIFF
--- a/src/dorsal.js
+++ b/src/dorsal.js
@@ -58,7 +58,15 @@ DorsalRuntime.prototype._getAttributes = function(el) {
     return this._getDataAttributes(el);
 }
 
-DorsalRuntime.prototype.bootstrap = function() {
+DorsalRuntime.prototype._runPlugin = function(plugin, el) {
+    var data = this._getAttributes(el);
+    plugin.call(el, {
+        el: el,
+        data: data
+    });
+}
+
+DorsalRuntime.prototype.wire = function(el) {
     if (!this.plugins) {
         throw new Error('No plugins registered with Dorsal');
     }
@@ -68,16 +76,20 @@ DorsalRuntime.prototype.bootstrap = function() {
         elementIndex = 0,
         length = pluginKeys.length,
         elements,
-        data;
+        data,
+        el = el || document,
+        pluginCSSClass;
 
     for (; index < length; index++) {
-        elements = document.querySelectorAll(this.CSS_PREFIX + pluginKeys[index]);
+        pluginCSSClass = this.CSS_PREFIX + pluginKeys[index];
+        elements = el.querySelectorAll(pluginCSSClass);
+
+        if (el !== document && el.className.indexOf(pluginCSSClass.substr(1)) > -1) {
+            this._runPlugin(this.plugins[pluginKeys[index]], el);
+        }
+
         for (elementIndex = 0; elementIndex < elements.length; elementIndex++) {
-            data = this._getAttributes(elements[elementIndex]);
-            this.plugins[pluginKeys[index]].call(elements[elementIndex], {
-                el: elements[elementIndex],
-                data: data
-            });
+            this._runPlugin(this.plugins[pluginKeys[index]], elements[elementIndex]);
         }
     }
 };

--- a/tests/dorsal.spec.js
+++ b/tests/dorsal.spec.js
@@ -33,13 +33,29 @@ describe("DorsalJS", function() {
                 options.el.innerHTML = 'hello, world';
             });
 
-            setFixtures('<div class="js-d-test"></div>');
-            this.dorsal.bootstrap();
+            this.html = '<div class="js-d-test"></div>';
+
+            setFixtures(this.html);
+            this.dorsal.wire();
         });
 
         it('runs the test plugin', function() {
             expect($('.js-d-test')).toHaveHtml('hello, world');
         });
+
+        describe('after initial wire', function() {
+
+            beforeEach(function() {
+                this.$el = $(this.html);
+                this.dorsal.wire(this.$el.get(0));
+            });
+
+            it('runs the test plugin on a DOM node', function() {
+                expect(this.$el).toHaveHtml('hello, world');
+            });
+
+        });
+
     });
 
     describe('data attributes', function() {
@@ -51,7 +67,7 @@ describe("DorsalJS", function() {
 
             this.html = '<div class="js-d-test" data-d-test-one-yay="hello" data-d-test-two-yay="world"></div>';
             setFixtures(this.html);
-            this.dorsal.bootstrap();
+            this.dorsal.wire();
         });
 
         it('gets data attributes without dataset', function() {


### PR DESCRIPTION
- Rename `bootstrap` to `wire`
- Accept an element for wire, defaults to document
## Testing
- TDD
