### PR TITLE
Lint warnings & a little optimization

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,3 @@
+{
+  "shadow" : true
+}

--- a/src/dorsal.js
+++ b/src/dorsal.js
@@ -44,11 +44,11 @@ DorsalCore.prototype._getDatasetAttributes = function(el) {
     }
 
     return dataAttributes;
-}
+};
 
-DorsalCore.prototype._normalizeDataAttribute =  function(attr, _) {
+DorsalCore.prototype._normalizeDataAttribute =  function(attr) {
     return attr.toUpperCase().replace('-','');
-            }
+};
 DorsalCore.prototype._getDataAttributes = function(el) {
     var dataAttributes = {},
         attributes = el.attributes,
@@ -66,7 +66,7 @@ DorsalCore.prototype._getDataAttributes = function(el) {
     }
 
     return dataAttributes;
-}
+};
 
 DorsalCore.prototype._getAttributes = function(el) {
     if (el.dataset) {
@@ -74,7 +74,7 @@ DorsalCore.prototype._getAttributes = function(el) {
     }
 
     return this._getDataAttributes(el);
-}
+};
 
 DorsalCore.prototype._runPlugin = function(plugin, el) {
     var data = this._getAttributes(el);
@@ -82,7 +82,7 @@ DorsalCore.prototype._runPlugin = function(plugin, el) {
         el: el,
         data: data
     });
-}
+};
 
 DorsalCore.prototype.wire = function(el) {
     if (!this.plugins) {
@@ -91,7 +91,6 @@ DorsalCore.prototype.wire = function(el) {
 
     var pluginKeys = Object.keys(this.plugins),
         index = 0,
-        elementIndex = 0,
         length = pluginKeys.length,
         elements,
         data,
@@ -106,8 +105,8 @@ DorsalCore.prototype.wire = function(el) {
             this._runPlugin(this.plugins[pluginKeys[index]], el);
         }
 
-        for (elementIndex = 0; elementIndex < elements.length; elementIndex++) {
-            this._runPlugin(this.plugins[pluginKeys[index]], elements[elementIndex]);
+        for (var elementIndex = 0, element; (element = elements[elementIndex]); elementIndex++) {
+            this._runPlugin(this.plugins[pluginKeys[index]], element);
         }
     }
 };


### PR DESCRIPTION
some lint warnings spotted in code_climate. 

also an iteration that was using `elements.length`. now should be faster 
