### PR TITLE
Added Rewire/Unwire Capabilities

### DIFF
--- a/src/dorsal.js
+++ b/src/dorsal.js
@@ -165,6 +165,10 @@ DorsalCore.prototype._detachPlugin = function(el, pluginName) {
     var remainingPlugins,
         hasActuallyDestroyed = false;
 
+    if (typeof el.getAttribute(this.DATA_DORSAL_WIRED) !== 'string') {
+        return false;
+    }
+
     if (el.getAttribute(this.DATA_DORSAL_WIRED).indexOf(pluginName) > -1 &&
         this.plugins[pluginName].destroy) {
 

--- a/tests/dorsal.spec.js
+++ b/tests/dorsal.spec.js
@@ -153,6 +153,10 @@
             this.clock.tick(10);
         });
 
+        it('does not explode when unwiring an unwired element', function() {
+            expect(this.dorsal.unwire($('<div>').get(0), 'pizza')).toBeFalsy();
+        });
+
         it('attaches multiple plugins to an element', function() {
             expect(this.$html.data('xdWired').indexOf('hello') > -1).toBeTruthy();
             expect(this.$html.data('xdWired').indexOf('world') > -1).toBeTruthy();


### PR DESCRIPTION
- Added a GUID to pass return values from create to destroy plugin
  functions
- Added create/destroy concept for plugins that need destroy
- Added unwire for specific and all plugins
- Added wire for specific plugins
- Prevented plugins from being wired if they have already been wired
- Added rewire, which first unwires then rewires either specific or
  all plugins
## Testing
- Mostly TDD
