### PR TITLE
Added prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "main": "dist/dorsal.js",
   "scripts": {
+    "prepublish": "grunt",
     "test": "grunt test"
   },
   "keywords": [


### PR DESCRIPTION
This lets us build before publishing a new version of dorsal.

@gagoar Should we also rebuild the github pages or anything?
